### PR TITLE
The USE_LOCAL_DATABASE variable was always true, it's now fixed.

### DIFF
--- a/backend-app/src/config/index.js
+++ b/backend-app/src/config/index.js
@@ -11,7 +11,7 @@ const {error} = validationSchema
 if (error) throw new Error(error);
 
 module.exports = {
-  USE_LOCAL_DATABASE: !parseInt(process.env.USE_LOCAL_DATABASE) ? 1 : process.env.USE_LOCAL_DATABASE,
+  USE_LOCAL_DATABASE: process.env.USE_LOCAL_DATABASE,
 
   PORT: !parseInt(process.env.PORT) ? 8080 : process.env.PORT,
 


### PR DESCRIPTION
Hasan Khalaf raised the issue to me that this was always true and that the expression was not neccesary since validation is done on this in validations.js.