### PR TITLE
Changed alpine version in dockerfile.

### DIFF
--- a/backend-app/Dockerfile
+++ b/backend-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine3.11
+FROM node:16-alpine3.15
 
 EXPOSE 8080 1337
 


### PR DESCRIPTION
Changed alpine version 3.11 seemed deprecated. This installs the newest LTS version of node inside the docker container.