### PR TITLE
Hotfix pagination token

### DIFF
--- a/backend-app/src/presentation-layer/services/cognito.admin.config.js
+++ b/backend-app/src/presentation-layer/services/cognito.admin.config.js
@@ -225,16 +225,8 @@ class AdminCognitoService {
         let params = {
             Limit: limit,
             UserPoolId: this.userPool,
-            GroupName: 'Users'
-        }
-
-        if (paginationToken !== undefined) {
-            params = {
-                NextToken: paginationToken,
-                Limit: limit,
-                UserPoolId: this.userPool,
-                GroupName: 'Users'
-            }
+            GroupName: 'Users',
+            NextToken: paginationToken
         }
 
         try {
@@ -277,16 +269,8 @@ class AdminCognitoService {
         let params = {
             Limit: limit,
             UserPoolId: this.userPool,
-            GroupName: 'Admins'
-        }
-
-        if (paginationToken !== undefined) {
-            params = {
-                NextToken: paginationToken,
-                Limit: limit,
-                UserPoolId: this.userPool,
-                GroupName: 'Admins'
-            }
+            GroupName: 'Admins',
+            NextToken: paginationToken
         }
 
         try {

--- a/backend-app/src/presentation-layer/services/cognito.admin.config.js
+++ b/backend-app/src/presentation-layer/services/cognito.admin.config.js
@@ -273,7 +273,6 @@ class AdminCognitoService {
             UserPoolId: this.userPool,
             GroupName: 'Admins'
         };
-        
         if(paginationToken !== undefined){
             params.NextToken = paginationToken;
         };

--- a/backend-app/src/presentation-layer/services/cognito.admin.config.js
+++ b/backend-app/src/presentation-layer/services/cognito.admin.config.js
@@ -225,8 +225,10 @@ class AdminCognitoService {
         let params = {
             Limit: limit,
             UserPoolId: this.userPool,
-            GroupName: 'Users',
-            NextToken: paginationToken
+            GroupName: 'Users'
+        }
+        if(paginationToken !== undefined){
+            params.NextToken = paginationToken;
         }
 
         try {
@@ -269,9 +271,12 @@ class AdminCognitoService {
         let params = {
             Limit: limit,
             UserPoolId: this.userPool,
-            GroupName: 'Admins',
-            NextToken: paginationToken
-        }
+            GroupName: 'Admins'
+        };
+        
+        if(paginationToken !== undefined){
+            params.NextToken = paginationToken;
+        };
 
         try {
             const res = await this.cognitoIdentity.listUsersInGroup(params).promise();

--- a/backend-app/src/presentation-layer/services/cognito.admin.config.js
+++ b/backend-app/src/presentation-layer/services/cognito.admin.config.js
@@ -230,7 +230,7 @@ class AdminCognitoService {
 
         if (paginationToken !== undefined) {
             params = {
-                PaginationToken: paginationToken,
+                NextToken: paginationToken,
                 Limit: limit,
                 UserPoolId: this.userPool,
                 GroupName: 'Users'
@@ -282,7 +282,7 @@ class AdminCognitoService {
 
         if (paginationToken !== undefined) {
             params = {
-                PaginationToken: paginationToken,
+                NextToken: paginationToken,
                 Limit: limit,
                 UserPoolId: this.userPool,
                 GroupName: 'Admins'


### PR DESCRIPTION
Cognito limits how many users you can get at a time with a cap of 60 per request.
A **token** is sent in the response. This is sent in a new request to get additional users that didnt fit in the first response.

When changing to use one user pool we now need to list users by group. When using this function cognito decided to rename the token from PaginationToken => NextToken :) 